### PR TITLE
Fix parsing and encoding vCard x-property values

### DIFF
--- a/design-data/vcard-properties.csv
+++ b/design-data/vcard-properties.csv
@@ -45,7 +45,7 @@
 "FBURL","34","URI","URI"
 "CALADRURI","35","URI","URI"
 "CALURI","36","URI","URI"
-"X","37","X","X",is_multivalued
+"X","37","X","X"
 
 "#Deprecated Properties","RFC 2425/2426",,,
 "NAME","38","TEXT","TEXT"

--- a/src/libicalvcard/vcardvalue.c
+++ b/src/libicalvcard/vcardvalue.c
@@ -830,12 +830,7 @@ char *vcardvalue_as_vcard_string_r(const vcardvalue *value)
 
     case VCARD_X_VALUE:
         if (value->x_value != 0) {
-            char *str = NULL;
-            char *str_p;
-            size_t buf_sz;
-
-            return vcardmemory_strdup_and_quote(&str, &str_p, &buf_sz,
-                                                value->x_value, 0);
+            return icalmemory_strdup(value->x_value);
         }
         _fallthrough();
 

--- a/src/test/libicalvcard/vcard_test_encode.c
+++ b/src/test/libicalvcard/vcard_test_encode.c
@@ -109,6 +109,7 @@ static void test_prop_x(void)
         "BEGIN:VCARD\r\n"
         "VERSION:3.0\r\n"
         "X-PROP:foo\r\n"
+        "X-PROP:foo;bar\r\n"
         "END:VCARD\r\n";
 
     vcardcomponent *card = vcardparser_parse_string(input);
@@ -119,6 +120,11 @@ static void test_prop_x(void)
     assert(prop != NULL);
     assert(VCARD_X_VALUE == vcardvalue_isa(vcardproperty_get_value(prop)));
     assert_str_equals("X-PROP:foo\r\n", vcardproperty_as_vcard_string(prop));
+
+    prop = vcardcomponent_get_next_property(card, VCARD_X_PROPERTY);
+    assert(prop != NULL);
+    assert(VCARD_X_VALUE == vcardvalue_isa(vcardproperty_get_value(prop)));
+    assert_str_equals("X-PROP:foo;bar\r\n", vcardproperty_as_vcard_string(prop));
 
     vcardcomponent_free(card);
 }

--- a/src/test/libicalvcard/vcard_test_encode.c
+++ b/src/test/libicalvcard/vcard_test_encode.c
@@ -103,6 +103,26 @@ static void test_prop_multivalued(void)
     vcardcomponent_free(card);
 }
 
+static void test_prop_x(void)
+{
+    static const char *input =
+        "BEGIN:VCARD\r\n"
+        "VERSION:3.0\r\n"
+        "X-PROP:foo\r\n"
+        "END:VCARD\r\n";
+
+    vcardcomponent *card = vcardparser_parse_string(input);
+    assert(card != NULL);
+
+    vcardproperty *prop =
+        vcardcomponent_get_first_property(card, VCARD_X_PROPERTY);
+    assert(prop != NULL);
+    assert(VCARD_X_VALUE == vcardvalue_isa(vcardproperty_get_value(prop)));
+    assert_str_equals("X-PROP:foo\r\n", vcardproperty_as_vcard_string(prop));
+
+    vcardcomponent_free(card);
+}
+
 static void test_param_singlevalued(void)
 {
     static const char *input =
@@ -159,6 +179,7 @@ int main(int argc, char **argv)
     test_prop_text();
     test_prop_structured();
     test_prop_multivalued();
+    test_prop_x();
 
     test_param_singlevalued();
     test_param_multivalued();


### PR DESCRIPTION
X-properties were marked as multi-valued in `design_data`, which caused their value kind to be set to TEXTLIST during parsing. They should instead be of kind X_VALUE.

Similarly, encoding an X_VALUE was done by escaping COMMA or SEMICOLON, which broke round-tripping unknown x-property values containing these characters.