### PR TITLE
vcardvalue.c: don't abort if first structured value field is empty

### DIFF
--- a/src/libicalvcard/vcardvalue.c
+++ b/src/libicalvcard/vcardvalue.c
@@ -686,7 +686,7 @@ char *vcardstructured_as_vcard_string_r(const vcardstructuredtype *s, bool is_pa
         vcardstrarray *array = s->field[i];
 
         if (i) {
-            buf_ptr -= 1; // backup to \0
+            if (buf_ptr > buf) buf_ptr -= 1; // backup to \0
             icalmemory_append_char(&buf, &buf_ptr, &buf_size, ';');
         }
 

--- a/src/test/libicalvcard/vcard_test_encode.c
+++ b/src/test/libicalvcard/vcard_test_encode.c
@@ -177,6 +177,56 @@ static void test_param_multivalued(void)
     vcardcomponent_free(card);
 }
 
+static void test_value_structured(void)
+{
+    vcardstructuredtype *stt;
+    vcardvalue *val;
+
+    // Set structured value having both fields set.
+    stt = vcardstructured_new();
+    stt->field[0] = vcardstrarray_new(1);
+    vcardstrarray_add(stt->field[0], "foo");
+    stt->field[1] = vcardstrarray_new(1);
+    vcardstrarray_add(stt->field[1], "bar");
+    stt->num_fields = 2;
+
+    val = vcardvalue_new_structured(stt);
+    assert_str_equals("foo;bar", vcardvalue_as_vcard_string(val));
+    vcardvalue_free(val);
+
+    // Set structured value having only first field set.
+    stt = vcardstructured_new();
+    stt->field[0] = vcardstrarray_new(1);
+    vcardstrarray_add(stt->field[0], "foo");
+    stt->field[1] = vcardstrarray_new(1);
+    stt->num_fields = 2;
+
+    val = vcardvalue_new_structured(stt);
+    assert_str_equals("foo;", vcardvalue_as_vcard_string(val));
+    vcardvalue_free(val);
+
+    // Set structured value having only second field set.
+    stt = vcardstructured_new();
+    stt->field[0] = vcardstrarray_new(1);
+    stt->field[1] = vcardstrarray_new(1);
+    vcardstrarray_add(stt->field[1], "bar");
+    stt->num_fields = 2;
+
+    val = vcardvalue_new_structured(stt);
+    assert_str_equals(";bar", vcardvalue_as_vcard_string(val));
+    vcardvalue_free(val);
+
+    // Set structured value having no field set.
+    stt = vcardstructured_new();
+    stt->field[0] = vcardstrarray_new(1);
+    stt->field[1] = vcardstrarray_new(1);
+    stt->num_fields = 2;
+
+    val = vcardvalue_new_structured(stt);
+    assert_str_equals(";", vcardvalue_as_vcard_string(val));
+    vcardvalue_free(val);
+}
+
 int main(int argc, char **argv)
 {
     _unused(argc);
@@ -189,6 +239,8 @@ int main(int argc, char **argv)
 
     test_param_singlevalued();
     test_param_multivalued();
+
+    test_value_structured();
 
     return 0;
 }


### PR DESCRIPTION
Fixes a bug in pointer arithmetic when the first field in a structured value is an empty list.