### PR TITLE
Fix parsing empty and escaped structured values

### DIFF
--- a/src/libicalvcard/vcardstructured.c
+++ b/src/libicalvcard/vcardstructured.c
@@ -69,6 +69,7 @@ vcardstructuredtype *vcardstructured_from_string(const char *s)
     }
 
     /* end of value */
+    pos = buf + len;
     icalmemory_append_char(&buf, &pos, &alloc, '\0');
     vcardstrarray_append(field, buf);
 

--- a/src/libicalvcard/vcardstructured.c
+++ b/src/libicalvcard/vcardstructured.c
@@ -47,6 +47,14 @@ vcardstructuredtype *vcardstructured_from_string(const char *s)
         pos = buf + len;
 
         switch (*s) {
+        case '\\':
+            if (s[1]) {
+                icalmemory_append_char(&buf, &pos, &alloc, s[1]);
+                len = (ptrdiff_t)(pos - buf);
+                s++;
+            }
+            break;
+
         case ',':
         case ';':
             /* end of value */

--- a/src/test/libicalvcard/vcard_test_encode.c
+++ b/src/test/libicalvcard/vcard_test_encode.c
@@ -227,6 +227,47 @@ static void test_value_structured(void)
     vcardvalue_free(val);
 }
 
+static void test_value_structured_from_string(void)
+{
+    vcardstructuredtype *stt;
+
+    // Parse structured value having both fields set.
+    stt = vcardstructured_from_string("foo;bar");
+    assert(stt->num_fields == 2);
+    assert(vcardstrarray_size(stt->field[0]) == 1);
+    assert(vcardstrarray_size(stt->field[1]) == 1);
+    assert_str_equals("foo", vcardstrarray_element_at(stt->field[0], 0));
+    assert_str_equals("bar", vcardstrarray_element_at(stt->field[1], 0));
+    vcardstructured_free(stt);
+
+    // Parse structured value having only first field set.
+    stt = vcardstructured_from_string("foo;");
+    assert(stt->num_fields == 2);
+    assert(vcardstrarray_size(stt->field[0]) == 1);
+    assert(vcardstrarray_size(stt->field[1]) == 1);
+    assert_str_equals("foo", vcardstrarray_element_at(stt->field[0], 0));
+    assert_str_equals("", vcardstrarray_element_at(stt->field[1], 0));
+    vcardstructured_free(stt);
+
+    // Parse structured value having only second field set.
+    stt = vcardstructured_from_string(";foo");
+    assert(stt->num_fields == 2);
+    assert(vcardstrarray_size(stt->field[0]) == 1);
+    assert(vcardstrarray_size(stt->field[1]) == 1);
+    assert_str_equals("", vcardstrarray_element_at(stt->field[0], 0));
+    assert_str_equals("foo", vcardstrarray_element_at(stt->field[1], 0));
+    vcardstructured_free(stt);
+
+    // Parse structured value having no field set.
+    stt = vcardstructured_from_string(";");
+    assert(stt->num_fields == 2);
+    assert(vcardstrarray_size(stt->field[0]) == 1);
+    assert(vcardstrarray_size(stt->field[1]) == 1);
+    assert_str_equals("", vcardstrarray_element_at(stt->field[0], 0));
+    assert_str_equals("", vcardstrarray_element_at(stt->field[1], 0));
+    vcardstructured_free(stt);
+}
+
 int main(int argc, char **argv)
 {
     _unused(argc);
@@ -241,6 +282,7 @@ int main(int argc, char **argv)
     test_param_multivalued();
 
     test_value_structured();
+    test_value_structured_from_string();
 
     return 0;
 }

--- a/src/test/libicalvcard/vcard_test_encode.c
+++ b/src/test/libicalvcard/vcard_test_encode.c
@@ -268,6 +268,45 @@ static void test_value_structured_from_string(void)
     vcardstructured_free(stt);
 }
 
+static void test_value_structured_escaped(void)
+{
+    vcardstructuredtype *stt = vcardstructured_new();
+
+    stt->field[0] = vcardstrarray_new(1);
+    vcardstrarray_add(stt->field[0], "foo,bar");
+    vcardstrarray_add(stt->field[0], "baz;bam");
+    stt->field[1] = vcardstrarray_new(1);
+    vcardstrarray_add(stt->field[1], "tux;");
+    vcardstrarray_add(stt->field[1], "qux,");
+    stt->num_fields = 2;
+
+    vcardvalue *val = vcardvalue_new_structured(stt);
+    assert_str_equals("foo\\,bar,baz\\;bam;tux\\;,qux\\,", vcardvalue_as_vcard_string(val));
+    vcardvalue_free(val);
+}
+
+static void test_value_structured_from_string_escaped(void)
+{
+    vcardstructuredtype *stt;
+
+    stt = vcardstructured_from_string("foo\\,bar,baz\\;bam;tux\\;,qux\\,");
+    assert(stt->num_fields == 2);
+    assert(vcardstrarray_size(stt->field[0]) == 2);
+    assert(vcardstrarray_size(stt->field[1]) == 2);
+    assert_str_equals("foo,bar", vcardstrarray_element_at(stt->field[0], 0));
+    assert_str_equals("baz;bam", vcardstrarray_element_at(stt->field[0], 1));
+    assert_str_equals("tux;", vcardstrarray_element_at(stt->field[1], 0));
+    assert_str_equals("qux,", vcardstrarray_element_at(stt->field[1], 1));
+    vcardstructured_free(stt);
+
+    stt = vcardstructured_from_string("foo,bar\\");
+    assert(stt->num_fields == 1);
+    assert(vcardstrarray_size(stt->field[0]) == 2);
+    assert_str_equals("foo", vcardstrarray_element_at(stt->field[0], 0));
+    assert_str_equals("bar", vcardstrarray_element_at(stt->field[0], 1));
+    vcardstructured_free(stt);
+}
+
 int main(int argc, char **argv)
 {
     _unused(argc);
@@ -283,6 +322,8 @@ int main(int argc, char **argv)
 
     test_value_structured();
     test_value_structured_from_string();
+    test_value_structured_escaped();
+    test_value_structured_from_string_escaped();
 
     return 0;
 }


### PR DESCRIPTION
This fixes parsing structured vCard values in the form `foo;` and `foo\;bar`.