### PR TITLE
Parse x-property values as unknown values and fix parsing structured values

### DIFF
--- a/design-data/vcard-properties.csv
+++ b/design-data/vcard-properties.csv
@@ -45,7 +45,7 @@
 "FBURL","34","URI","URI"
 "CALADRURI","35","URI","URI"
 "CALURI","36","URI","URI"
-"X","37","X","X",is_multivalued
+"X","37","X","X"
 
 "#Deprecated Properties","RFC 2425/2426",,,
 "NAME","38","TEXT","TEXT"

--- a/src/libicalvcard/vcardparser.c
+++ b/src/libicalvcard/vcardparser.c
@@ -26,6 +26,9 @@
 
 #define DEBUG 0
 
+static ICAL_GLOBAL_VAR vcard_xprop_value_kind_func xprop_value_kind_func = NULL;
+static ICAL_GLOBAL_VAR void *xprop_value_kind_data = NULL;
+
 enum parse_error
 {
     PE_OK = 0,
@@ -596,6 +599,12 @@ static int _parse_prop_name(struct vcardparser_state *state)
                 state->value_kind = version == VCARD_VERSION_40 ? VCARD_URI_VALUE : VCARD_TEXT_VALUE;
                 break;
 
+            case VCARD_X_PROPERTY:
+              state->value_kind =
+                  xprop_value_kind_func ? xprop_value_kind_func(name, xprop_value_kind_data)
+                                    : VCARD_X_VALUE;
+              break;
+
             default:
                 state->value_kind = vcardproperty_kind_to_value_kind(kind);
                 break;
@@ -1050,4 +1059,10 @@ vcardcomponent *vcardparser_parse_string(const char *str)
     vcardparser_free(&parser);
 
     return vcard;
+}
+
+void vcardparser_set_xprop_value_kind(vcard_xprop_value_kind_func func, void *data)
+{
+    xprop_value_kind_func = func;
+    xprop_value_kind_data = data;
 }

--- a/src/libicalvcard/vcardparser.h
+++ b/src/libicalvcard/vcardparser.h
@@ -12,8 +12,47 @@
 
 #include "libical_vcard_export.h"
 #include "vcardcomponent.h"
+#include "vcardderivedvalue.h"
 
 LIBICAL_VCARD_EXPORT vcardcomponent *vcardparser_parse_string(const char *str);
 LIBICAL_VCARD_EXPORT const char *vcardparser_errstr(int err);
+
+/**
+ * @brief Callback function pointer to define x-property default value types.
+ *
+ * This typedef defines a pointer to a function that the vCard parser calls
+ * to determine the default value type of an x-property.
+ *
+ * @param name The name of the x-property currently parsed. This is the name as
+ * it appears in the vCard data except that it already is unfolded, e.g. it is
+ * not normalized to upper case.
+ * @param data A pointer to some user-defined callback data. Can be NULL.
+ * @return The default value type. Return VCARD_X_VALUE if unknown.
+ *
+ * @see vcardparser_set_xprop_value_kind() how to set the callback.
+ */
+typedef vcardvalue_kind(*vcard_xprop_value_kind_func)(const char *name, void *data);
+
+/**
+ * @brief Registers a parser callback to override the default value type of an
+ * x-property.
+ *
+ * Extended properties ("x-properties") in vCard do not have a default value
+ * type. Instead, they are parsed as unknown values and preserved verbatim.
+ * This function allows to register a callback to define the default value
+ * type for some x-property. Any VALUE parameter set on the property overrides
+ * the default value.
+ *
+ * @param func The function pointer to the callback. Use NULL to disable a
+ * previously registered callback.
+ * @param data Some callback-specific data. Can be NULL.
+ *
+ * For example, the callback might return VCARD_TEXT_VALUE when parsing an
+ * x-property named "X-ABLabel".
+ *
+ * This function is not reentrant. Depending on libical is built, the callback
+ * either is registered as a process-global or thread-local variable.
+ */
+LIBICAL_VCARD_EXPORT void vcardparser_set_xprop_value_kind(vcard_xprop_value_kind_func func, void *data);
 
 #endif /* VCARDPARSER_H */

--- a/src/libicalvcard/vcardstructured.c
+++ b/src/libicalvcard/vcardstructured.c
@@ -47,6 +47,14 @@ vcardstructuredtype *vcardstructured_from_string(const char *s)
         pos = buf + len;
 
         switch (*s) {
+        case '\\':
+            if (s[1]) {
+                icalmemory_append_char(&buf, &pos, &alloc, s[1]);
+                len = (ptrdiff_t)(pos - buf);
+                s++;
+            }
+            break;
+
         case ',':
         case ';':
             /* end of value */
@@ -69,6 +77,7 @@ vcardstructuredtype *vcardstructured_from_string(const char *s)
     }
 
     /* end of value */
+    pos = buf + len;
     icalmemory_append_char(&buf, &pos, &alloc, '\0');
     vcardstrarray_append(field, buf);
 

--- a/src/libicalvcard/vcardvalue.c
+++ b/src/libicalvcard/vcardvalue.c
@@ -437,10 +437,7 @@ static vcardvalue *vcardvalue_new_from_string_with_error(vcardvalue_kind kind,
         break;
 
     case VCARD_X_VALUE: {
-        char *dequoted_str = vcardvalue_strdup_and_dequote_text(&str, NULL);
-
-        value = vcardvalue_new_x(dequoted_str);
-        icalmemory_free_buffer(dequoted_str);
+        value = vcardvalue_new_x(str);
     } break;
 
     default: {
@@ -830,12 +827,7 @@ char *vcardvalue_as_vcard_string_r(const vcardvalue *value)
 
     case VCARD_X_VALUE:
         if (value->x_value != 0) {
-            char *str = NULL;
-            char *str_p;
-            size_t buf_sz;
-
-            return vcardmemory_strdup_and_quote(&str, &str_p, &buf_sz,
-                                                value->x_value, 0);
+            return icalmemory_strdup(value->x_value);
         }
         _fallthrough();
 

--- a/src/libicalvcard/vcardvalue.c
+++ b/src/libicalvcard/vcardvalue.c
@@ -686,7 +686,7 @@ char *vcardstructured_as_vcard_string_r(const vcardstructuredtype *s, bool is_pa
         vcardstrarray *array = s->field[i];
 
         if (i) {
-            buf_ptr -= 1; // backup to \0
+            if (buf_ptr > buf) buf_ptr -= 1; // backup to \0
             icalmemory_append_char(&buf, &buf_ptr, &buf_size, ';');
         }
 


### PR DESCRIPTION
This changes how values of extended properties ("x-properties") are parsed and encoded for vCards. Until now, such values were parsed and encoded as TEXT values. Now they are handled as values of unknown type.

In addition to changing the default value to X-VALUE, this adds a callback to the vCard parser so that libicalvcard callers can specify he value kind per parsed x-property.

Handling these values as TEXT was incorrect: neither vCard 4 (RFC 6350) nor vCard 3 (RFC 2426) defined extended properties to have default value TEXT. This is in contrast to iCalendar which does define their default value to be TEXT (RFC 5545, Section 3.8.8.2).

This was especially problematic because in vCard the COMMA and SEMICOLON characters signify a separator for structured values.  Parsing values as TEXT caused these characters to be leniently read as unescaped characters but then become escaped during encoding. As a result, values of x-properties containing these characters differed from their original when encoded, which could change semantics.

It also fixes a couple of bugs when parsing and encoding structured values.